### PR TITLE
リンクの修正

### DIFF
--- a/1.BuildApp.md
+++ b/1.BuildApp.md
@@ -90,7 +90,7 @@ sail stop
 ~~~
 
 11. 立ち上げたプロジェクトへアクセス
-> http://localhost/　にアクセスすれば起動したLaravelプロジェクトにアクセスできる。
+> http://localhost/ にアクセスすれば起動したLaravelプロジェクトにアクセスできる。
 
 
 ### sailコマンドの補足


### PR DESCRIPTION
全角スペースだと、後続の文章を含めたリンクになるので、半角スペースに変更